### PR TITLE
fix #3: skip `probe_platform_engines!` on 1.8

### DIFF
--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -46,7 +46,7 @@ function add_artifact!(
     clear=true,
     options...,
 )
-    probe_platform_engines!()
+    @static isdefined(PlatformEngines, :probe_platform_engines!) && probe_platform_engines!()
 
     tarball_path = download(tarball_url)
     sha256 = sha256sum(tarball_path)


### PR DESCRIPTION
I did test this with Pkg#master.