### PR TITLE
use Downloads.jl instead of `Base.download`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Simeon Schaub <simeondavidschaub99@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -4,6 +4,7 @@ using Pkg.Artifacts
 using Pkg.PlatformEngines
 using Pkg.GitTools
 using SHA
+using Downloads: download
 
 export add_artifact!
 


### PR DESCRIPTION
Fixes the deprecation warning.