### PR TITLE
Add upload_to_gist and artifact_from_directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.7'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
+          - '1.7'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.1"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -12,6 +13,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 gh_cli_jll = "5d31d589-30fb-542f-b82d-10325e863e38"
 
 [compat]
+Git = "1"
 HTTP = "0.9"
 gh_cli_jll = "2"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,14 @@ version = "0.1.1"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+gh_cli_jll = "5d31d589-30fb-542f-b82d-10325e863e38"
 
 [compat]
+gh_cli_jll = "2"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 gh_cli_jll = "5d31d589-30fb-542f-b82d-10325e863e38"
 
 [compat]
+HTTP = "0.9"
 gh_cli_jll = "2"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ gh_cli_jll = "5d31d589-30fb-542f-b82d-10325e863e38"
 [compat]
 HTTP = "0.9"
 gh_cli_jll = "2"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/README.md
+++ b/README.md
@@ -39,3 +39,60 @@ julia> run(`ls $ans`);
 JuliaMono-Black.ttf	JuliaMono-Bold.ttf	 JuliaMono-Light.ttf	JuliaMono-RegularLatin.ttf  LICENSE
 JuliaMono-BoldLatin.ttf  JuliaMono-ExtraBold.ttf  JuliaMono-Medium.ttf	JuliaMono-Regular.ttf
 ```
+
+### Archive a directory and upload it to gist
+
+You can create an artifact from a directory using `artifact_from_directory` and
+then upload it to gist with `upload_to_gist`.  Note that `upload_to_gist`
+requires login with the [GitHub CLI `gh`](https://github.com/cli/cli).
+
+```julia
+julia> using ArtifactUtils
+
+julia> tempdir = mktempdir();
+
+julia> write(joinpath(tempdir, "file"), "hello");
+
+julia> artifact = artifact_from_directory(tempdir)
+SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
+
+julia> gist = upload_to_gist(artifact)
+- Creating gist...
+✓ Created gist
+Cloning into '.'...
+remote: Enumerating objects: 3, done.
+remote: Counting objects: 100% (3/3), done.
+remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
+Receiving objects: 100% (3/3), done.
+Switched to a new branch '__tmp__'
+[__tmp__ (root-commit) f5a58a9] Initial commit
+Switched to branch 'master'
+Your branch is up to date with 'origin/master'.
+HEAD is now at f5a58a9 Initial commit
+[master 44dfe9a] Add files
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ create mode 100644 538e83d637ab07ada6d841aa2454e0d5af4e52b3.tar.gz
+Counting objects: 5, done.
+Delta compression using up to 128 threads.
+Compressing objects: 100% (4/4), done.
+Writing objects: 100% (5/5), 455 bytes | 455.00 KiB/s, done.
+Total 5 (delta 1), reused 0 (delta 0)
+remote: Resolving deltas: 100% (1/1), done.
+To gist.github.com:a9ceed430ff970412fc6606ef1b84b6a
+ + 2668e40...44dfe9a master -> master (forced update)
+upload_to_gist(SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")) →
+
+[538e83d637ab07ada6d841aa2454e0d5af4e52b3]
+git-tree-sha1 = "538e83d637ab07ada6d841aa2454e0d5af4e52b3"
+
+    [[538e83d637ab07ada6d841aa2454e0d5af4e52b3.download]]
+    sha256 = "a530e9f7e371eeea4aa4fbce83a00ed32233b7766314670b1c0779eb46a7b68d"
+    url = "https://gist.github.com/tkf/a9ceed430ff970412fc6606ef1b84b6a/raw/538e83d637ab07ada6d841aa2454e0d5af4e52b3.tar.gz"
+```
+
+You can copy-and-paste the printed artifact fragment into your `Artifacts.toml`
+file.  You can also call `add_artifact!` with the `gist` result object.
+
+```julia
+julia> add_artifact!("Artifacts.toml", "hello_world", gist)
+```

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ julia> tempdir = mktempdir();
 
 julia> write(joinpath(tempdir, "file"), "hello");
 
-julia> artifact = artifact_from_directory(tempdir)
+julia> artifact_id = artifact_from_directory(tempdir)
 SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
 
-julia> gist = upload_to_gist(artifact)
+julia> gist = upload_to_gist(artifact_id)
 - Creating gist...
 ✓ Created gist
 Cloning into '.'...

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,8 @@ CurrentModule = ArtifactUtils
 
 ```@index
 add_artifact!
+artifact_from_directory
+upload_to_gist
 ```
 
 ```@autodocs

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -91,10 +91,23 @@ artifact_from_directory(source) =
         Sys.iswindows() && copy_mode(source, artifact_dir)
     end
 
-# https://github.com/JuliaIO/Tar.jl/blob/6a946029685639b69ce5a7cc4c4a6c0e6c6b2697/src/extract.jl#L145-L153
-function copy_mode(src::String, dst::String)
-    chmod(dst, filemode(src))
-    isdir(dst) || return
+"""
+    copy_mode(src, dst)
+
+Copy mode of `src` to `dst` recursively in a way compatible to how `Pkg` (Git)
+compute the tree hash.
+
+See `Pkg.GitTools.gitmode` comment for how the file mode is handled specially in Windows:
+https://github.com/JuliaLang/Pkg.jl/blob/247a4062bfde19d93bdcbaccc9737df496fd0c2b/src/GitTools.jl#L189-L192
+
+`copy_mode` is based on:
+https://github.com/JuliaIO/Tar.jl/blob/6a946029685639b69ce5a7cc4c4a6c0e6c6b2697/src/extract.jl#L145-L153
+"""
+function copy_mode(src, dst)
+    if !isdir(dst)
+        chmod(dst, UInt(GitTools.gitmode(string(src))))
+        return
+    end
     for name in readdir(dst)
         sub_src = joinpath(src, name)
         sub_dst = joinpath(dst, name)

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -6,7 +6,7 @@ using Pkg.GitTools
 using SHA
 using Downloads: download
 
-export add_artifact!
+export add_artifact!, artifact_from_directory
 
 function sha256sum(tarball_path)
     return open(tarball_path, "r") do io
@@ -69,5 +69,15 @@ function add_artifact!(
 
     return git_tree_sha1
 end
+
+"""
+    artifact_from_directory(source) -> artifact::SHA1
+
+Create an artifact from the `source` directory and return the `artifact` hash.
+"""
+artifact_from_directory(source) =
+    create_artifact() do artifact_dir
+        cp(source, artifact_dir; force = true, follow_symlinks = true)
+    end
 
 end

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -1,12 +1,18 @@
 module ArtifactUtils
 
+import HTTP
+import TOML
+import gh_cli_jll
 using Pkg.Artifacts
 using Pkg.PlatformEngines
 using Pkg.GitTools
+using Base: SHA1
 using SHA
 using Downloads: download
 
-export add_artifact!, artifact_from_directory
+export add_artifact!, artifact_from_directory, upload_to_gist
+
+include("gistutils.jl")
 
 function sha256sum(tarball_path)
     return open(tarball_path, "r") do io
@@ -44,10 +50,11 @@ function add_artifact!(
     artifacts_toml::String,
     name::String,
     tarball_url::String;
-    clear=true,
+    clear = true,
     options...,
 )
-    @static isdefined(PlatformEngines, :probe_platform_engines!) && probe_platform_engines!()
+    @static isdefined(PlatformEngines, :probe_platform_engines!) &&
+            probe_platform_engines!()
 
     tarball_path = download(tarball_url)
     sha256 = sha256sum(tarball_path)
@@ -79,5 +86,137 @@ artifact_from_directory(source) =
     create_artifact() do artifact_dir
         cp(source, artifact_dir; force = true, follow_symlinks = true)
     end
+
+struct GistUploadResult
+    artifact::SHA1
+    filename::String
+    localpath::Union{String,Nothing}
+    url::String
+    sha256::String
+    private::Bool
+end
+
+"""
+    upload_to_gist(
+        artifact::SHA1,
+        [tarball];
+        private::Bool = true,
+        archive_artifact = (),
+        # Following options are aviailable only when `tarball` is not specified:
+        name::AbstractString = "\$artifact.tar.gz",
+        extension::AbstractString = ".tar.gz",
+    ) -> gist
+
+Create an `artifact` archive at path `tarball` (or in a temporary location) and upload it to
+gist. The returned value `gist` can be passed to `add_artifact!`.
+
+# Extended help
+
+## Examples
+```julia
+using ArtifactUtils
+add_artifact!("Artifact.toml", "name", upload_to_gist(artifact_from_directory("source")))
+```
+
+creates an artifact from files in the `"source"` directory, upload it to gist, and then
+add it to `"Artifact.toml"` with the name `"name"`.
+
+## Keyword Arguments
+- `private`: if `true`, upload the archive to a private gist
+- `archive_artifact`: keyword arguments passed to `Pkg.Artifacts.archive_artifact`
+- `name`: name of the archive file, including file extension
+- `extension`: file extension of the tarball. It can be used for specifying the compression
+  method.
+"""
+function upload_to_gist end
+
+function upload_to_gist(
+    artifact::SHA1,
+    tarball::AbstractString;
+    private::Bool = true,
+    archive_artifact = (),
+)
+    mkpath(dirname(tarball))
+    (@__MODULE__).archive_artifact(artifact, tarball; archive_artifact...)
+    sha256 = sha256sum(tarball)
+    url = gist_from_file(tarball; private = private)
+    return GistUploadResult(
+        artifact,
+        basename(tarball),
+        abspath(tarball),
+        url,
+        sha256,
+        private,
+    )
+end
+
+function upload_to_gist(
+    artifact::SHA1;
+    name::Union{AbstractString,Nothing} = nothing,
+    extension::Union{AbstractString,Nothing} = nothing,
+    options...,
+)
+    if name !== nothing && extension !== nothing
+        error(
+            "Options `name` and `extension` are mutually exclusive. Got: name = ",
+            name,
+            " extension = ",
+            extension,
+        )
+    end
+
+    tarball = if name === nothing
+        string(artifact, something(extension, ".tar.gz"))
+    else
+        name
+    end
+
+    return mktempdir() do dir
+        upload_to_gist(artifact, joinpath(dir, tarball); options...)
+    end
+end
+
+function add_artifact!(
+    artifacts_toml::String,
+    name::String,
+    gist::GistUploadResult;
+    options...,
+)
+    bind_artifact!(
+        artifacts_toml,
+        name,
+        gist.artifact;
+        download_info = [(gist.url, gist.sha256)],
+        options...,
+    )
+end
+
+print_artifact_entry(gist::GistUploadResult; options...) =
+    print_artifact_entry(stdout, gist; options...)
+function print_artifact_entry(
+    io::IO,
+    gist::GistUploadResult;
+    name::AbstractString = replace(gist.filename, r"\.tar.[^\.]*$" => ""),
+)
+    dict = Dict(
+        name => Dict(
+            "git-tree-sha1" => string(gist.artifact),
+            "download" => [Dict("url" => gist.url, "sha256" => gist.sha256)],
+        ),
+    )
+    TOML.print(io, dict)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", gist::GistUploadResult)
+    print(io, upload_to_gist, "(")
+    show(io, gist.artifact)
+    if !gist.private
+        print(io, "; private = false")
+    end
+    println(io, ") →")
+    println(io)
+
+    print(io, strip(sprint(print_artifact_entry, gist)))
+end
 
 end

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -85,13 +85,7 @@ Create an artifact from the `source` directory and return the `artifact_id`.
 """
 artifact_from_directory(source) =
     create_artifact() do artifact_dir
-        @show readdir(source)
-        @show read.(readdir(source; join = true), String) 
-        @show SHA1(GitTools.tree_hash(source))
         cp(source, artifact_dir; force = true, follow_symlinks = true)
-        @show readdir(artifact_dir)
-        @show read.(readdir(artifact_dir; join = true), String) 
-        @show SHA1(GitTools.tree_hash(artifact_dir))
     end
 
 struct GistUploadResult

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -101,7 +101,7 @@ end
         artifact_id::SHA1,
         [tarball];
         private::Bool = true,
-        archive_artifact = (),
+        honor_overrides = false,
         # Following options are aviailable only when `tarball` is not specified:
         name::AbstractString = "\$artifact_id.tar.gz",
         extension::AbstractString = ".tar.gz",
@@ -123,10 +123,10 @@ add it to `"Artifact.toml"` with the name `"name"`.
 
 ## Keyword Arguments
 - `private`: if `true`, upload the archive to a private gist
-- `archive_artifact`: keyword arguments passed to `Pkg.Artifacts.archive_artifact`
 - `name`: name of the archive file, including file extension
 - `extension`: file extension of the tarball. It can be used for specifying the compression
   method.
+- `honor_overrides`: see `Pkg.Artifacts.archive_artifact`
 """
 function upload_to_gist end
 
@@ -134,10 +134,10 @@ function upload_to_gist(
     artifact_id::SHA1,
     tarball::AbstractString;
     private::Bool = true,
-    archive_artifact = (),
+    archive_options...,
 )
     mkpath(dirname(tarball))
-    (@__MODULE__).archive_artifact(artifact_id, tarball; archive_artifact...)
+    archive_artifact(artifact_id, tarball; archive_options...)
     sha256 = sha256sum(tarball)
     url = gist_from_file(tarball; private = private)
     return GistUploadResult(

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -86,8 +86,10 @@ Create an artifact from the `source` directory and return the `artifact_id`.
 artifact_from_directory(source) =
     create_artifact() do artifact_dir
         @show readdir(source)
+        @show read.(readdir(source; join = true), String) 
         cp(source, artifact_dir; force = true, follow_symlinks = true)
         @show readdir(artifact_dir)
+        @show read.(readdir(artifact_dir; join = true), String) 
     end
 
 struct GistUploadResult

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -84,7 +84,9 @@ Create an artifact from the `source` directory and return the `artifact_id`.
 """
 artifact_from_directory(source) =
     create_artifact() do artifact_dir
+        @show readdir(source)
         cp(source, artifact_dir; force = true, follow_symlinks = true)
+        @show readdir(artifact_dir)
     end
 
 struct GistUploadResult

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -87,9 +87,11 @@ artifact_from_directory(source) =
     create_artifact() do artifact_dir
         @show readdir(source)
         @show read.(readdir(source; join = true), String) 
+        @show SHA1(GitTools.tree_hash(source))
         cp(source, artifact_dir; force = true, follow_symlinks = true)
         @show readdir(artifact_dir)
         @show read.(readdir(artifact_dir; join = true), String) 
+        @show SHA1(GitTools.tree_hash(artifact_dir))
     end
 
 struct GistUploadResult

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -79,13 +79,13 @@ function add_artifact!(
 end
 
 """
-    artifact_from_directory(source) -> artifact_id::SHA1
+    artifact_from_directory(source; follow_symlinks = false) -> artifact_id::SHA1
 
 Create an artifact from the `source` directory and return the `artifact_id`.
 """
-artifact_from_directory(source) =
+artifact_from_directory(source; follow_symlinks::Bool = false) =
     create_artifact() do artifact_dir
-        cp(source, artifact_dir; force = true, follow_symlinks = true)
+        cp(source, artifact_dir; force = true, follow_symlinks = follow_symlinks)
         # Manually copy the executable bit in Windows:
         # https://github.com/simeonschaub/ArtifactUtils.jl/pull/8#discussion_r767210865
         Sys.iswindows() && copy_mode(source, artifact_dir)

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -82,6 +82,10 @@ end
     artifact_from_directory(source) -> artifact_id::SHA1
 
 Create an artifact from the `source` directory and return the `artifact_id`.
+
+!!! note
+    Known bug: In Windows, permission of files in `source` are ignored due to a limitation
+    of `Base.cp`.
 """
 artifact_from_directory(source) =
     create_artifact() do artifact_dir

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -1,5 +1,6 @@
 module ArtifactUtils
 
+import Git
 import HTTP
 import TOML
 import gh_cli_jll

--- a/src/gistutils.jl
+++ b/src/gistutils.jl
@@ -1,0 +1,104 @@
+"""
+    gist_from_file(filepath::AbstractString; private::Bool = true) -> fileurl::String
+
+Create a new gist from file at `filepath`. Return the "raw" HTTPS URL of the file.
+"""
+function gist_from_file(filepath::AbstractString; private::Bool = true)
+    @assert isfile(filepath)
+    # Using `with_new_gist` utility defined below instead of simply calling `gh gist create
+    # $filepath`. This seems to be required when the file at `filepath` is not a text file.
+    repo_http = with_new_gist(; private = private) do git_dir
+        cp(filepath, joinpath(git_dir, basename(filepath)))
+    end
+    return rstrip(repo_http, '/') * "/raw/" * basename(filepath)
+end
+
+"""
+    with_new_gist(f; private::Bool = true) -> repo_http::AbstractString
+
+Create a new gist, check it out as a local git repository at a temporary directory
+`git_dir`, call `f(git_dir)`, and then push it to remote.  Return the canonical gist HTTPS
+URL.
+"""
+function with_new_gist(f; private::Bool = true)
+    cmd = gh_cli_jll.gh()
+    cmd = `$cmd gist create`
+    if !private
+        cmd = `$cmd --public`
+    end
+    repo_http = chomp(String(communicate(cmd, "dummy")))
+
+    m = match(r"https://gist.github.com/(.*)", repo_http)
+    if m === nothing
+        error("Unrecognized output from `gh cli`: ", repo_http)
+    end
+    slug = m[1]
+    git_url = "git@gist.github.com:$slug"
+
+    response = Ref{HTTP.Response}()
+    @sync begin
+        # Get https://gist.github.com/$user/$slug from https://gist.github.com/$slug
+        @async response[] = HTTP.head(repo_http; redirect = false)
+
+        mktempdir() do git_dir
+            git(args) = run(`git -C $git_dir $args`)
+            git(`clone $git_url .`)
+            git_empty_history(git_dir)
+            f(git_dir)
+            git(`add .`)
+            git(`commit --allow-empty -m "Add files"`)
+            git(`push origin --force-with-lease`)
+        end
+    end
+
+    return get(Dict(response[].headers), "Location", repo_http)
+end
+
+"""
+    git_empty_history(git_dir)
+
+Empty the history of the current branch. Create an empty commit to start fresh.
+"""
+function git_empty_history(git_dir)
+    git(args) = run(`git -C $git_dir $args`)
+    branch = strip(read(`git -C $git_dir rev-parse --abbrev-ref HEAD`, String))
+    git(`checkout --orphan=__tmp__`)
+    for path in readdir(git_dir; join = true)
+        basename(path) == ".git" && continue
+        rm(path)
+    end
+    git(`add .`)
+    git(`commit --allow-empty -m "Initial commit"`)
+    git(`checkout $branch`)
+    git(`reset --hard __tmp__`)
+    return
+
+end
+
+"""
+    communicate(cmd, input) -> output::Vector{UInt8}
+
+Run `cmd`, write `input` to its stdin, and return the bytes `output` read from its stdout.
+stderr is redirected to `Base.stdout`.
+"""
+function communicate(cmd, input)
+    ipipe = Pipe()
+    opipe = Pipe()
+    proc = run(pipeline(cmd; stdin = ipipe, stdout = opipe, stderr = stderr); wait = false)
+    local output
+    @sync try
+        close(opipe.in)
+        @async try
+            write(ipipe, input)
+        finally
+            close(ipipe)
+        end
+        output = read(opipe)
+        wait(proc)
+    catch
+        close(ipipe)
+        close(opipe)
+        rethrow()
+    end
+    return output
+end

--- a/src/gistutils.jl
+++ b/src/gistutils.jl
@@ -72,7 +72,6 @@ function git_empty_history(git_dir)
     git(`checkout $branch`)
     git(`reset --hard __tmp__`)
     return
-
 end
 
 """

--- a/src/gistutils.jl
+++ b/src/gistutils.jl
@@ -41,7 +41,7 @@ function with_new_gist(f; private::Bool = true)
         @async response[] = HTTP.head(repo_http; redirect = false)
 
         mktempdir() do git_dir
-            git(args) = run(`git -C $git_dir $args`)
+            git(args) = run(`$(Git.git()) -C $git_dir $args`)
             git(`clone $git_url .`)
             git_empty_history(git_dir)
             f(git_dir)
@@ -60,7 +60,7 @@ end
 Empty the history of the current branch. Create an empty commit to start fresh.
 """
 function git_empty_history(git_dir)
-    git(args) = run(`git -C $git_dir $args`)
+    git(args) = run(`$(Git.git()) -C $git_dir $args`)
     branch = strip(read(`git -C $git_dir rev-parse --abbrev-ref HEAD`, String))
     git(`checkout --orphan=__tmp__`)
     for path in readdir(git_dir; join = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,7 +70,9 @@ end
 
 @testset "artifact_from_directory" begin
     mktempdir() do tempdir
-        write(joinpath(tempdir, "file"), "hello")
+        file = joinpath(tempdir, "file")
+        write(file, "hello")
+        chmod(file, 0o644)
         @test artifact_from_directory(tempdir) ==
               SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,11 +68,15 @@ end
     @test occursin("url =", str)
 end
 
+tree_hash(root::AbstractString; kwargs...) =
+    bytes2hex(Pkg.GitTools.tree_hash(root; kwargs...))
+
 @testset "artifact_from_directory" begin
     mktempdir() do tempdir
         file = joinpath(tempdir, "file")
         write(file, "hello")
         chmod(file, 0o644)
+        @test tree_hash(tempdir) == "538e83d637ab07ada6d841aa2454e0d5af4e52b3"
         @test artifact_from_directory(tempdir) ==
               SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,13 +78,14 @@ end
         chmod(file, 0o644)
         @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
               SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
-        if Sys.iswindows()
-            @test artifact_from_directory(tempdir) ==
-                SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
-        else
-            @test artifact_from_directory(tempdir) ==
-                SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
-        end
+        @test artifact_from_directory(tempdir) ==
+            SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
+
+        chmod(file, 0o744) # user x bit matters
+        @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
+              SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
+        @test artifact_from_directory(tempdir) ==
+            SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
     end
 end
 # Hashes taken from:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base: SHA1
 using Test
 using TOML
 import Pkg
+import Git
 
 function _artifact(name, loc)
     eval(Expr(:macrocall, Symbol("@artifact_str"), LineNumberNode(1, Symbol(loc)), name))
@@ -83,30 +84,27 @@ tree_hash(root::AbstractString; kwargs...) =
 end
 
 @testset "git_empty_history" begin
-    if success(`git --help`)
-        mktempdir() do git_dir
-            git(args) = run(`git --no-pager -C $git_dir $args`)
-            git(`init`)
+    mktempdir() do git_dir
+        git(args) = run(`$(Git.git()) --no-pager -C $git_dir $args`)
+        git(`init`)
 
-            # Setup repository-local user name and email so that it works on CI
-            git(`config user.email "test@example.com"`)
-            git(`config user.name "tester"`)
+        # Setup repository-local user name and email so that it works on CI
+        git(`config user.email "test@example.com"`)
+        git(`config user.name "tester"`)
 
-            git(`checkout -b new-branch`)
-            write(joinpath(git_dir, "file-1"), "content")
-            git(`add file-1`)
-            git(`commit --message "Add file-1"`)
-            history = strip(read(`git -C $git_dir --no-pager log`, String))
-            @test occursin("Add file-1", history)
+        git(`checkout -b new-branch`)
+        write(joinpath(git_dir, "file-1"), "content")
+        git(`add file-1`)
+        git(`commit --message "Add file-1"`)
+        history = strip(read(`git -C $git_dir --no-pager log`, String))
+        @test occursin("Add file-1", history)
 
-            ArtifactUtils.git_empty_history(git_dir)
-            @test !isfile("file-1")
-            branch = strip(
-                read(`git -C $git_dir --no-pager rev-parse --abbrev-ref HEAD`, String),
-            )
-            @test branch == "new-branch"
-            history = strip(read(`git -C $git_dir --no-pager log`, String))
-            @test !occursin("Add file-1", history)
-        end
+        ArtifactUtils.git_empty_history(git_dir)
+        @test !isfile("file-1")
+        branch =
+            strip(read(`git -C $git_dir --no-pager rev-parse --abbrev-ref HEAD`, String))
+        @test branch == "new-branch"
+        history = strip(read(`git -C $git_dir --no-pager log`, String))
+        @test !occursin("Add file-1", history)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,15 +69,13 @@ end
     @test occursin("url =", str)
 end
 
-tree_hash(root::AbstractString; kwargs...) =
-    bytes2hex(Pkg.GitTools.tree_hash(root; kwargs...))
-
 @testset "artifact_from_directory" begin
     mktempdir() do tempdir
         file = joinpath(tempdir, "file")
         write(file, "hello")
         chmod(file, 0o644)
-        @test tree_hash(tempdir) == "538e83d637ab07ada6d841aa2454e0d5af4e52b3"
+        @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
+              SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
         @test artifact_from_directory(tempdir) ==
               SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,13 +79,13 @@ end
         @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
               SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
         @test artifact_from_directory(tempdir) ==
-            SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
+              SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
 
         chmod(file, 0o744) # user x bit matters
         @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
               SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
         @test artifact_from_directory(tempdir) ==
-            SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
+              SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
     end
 end
 # Hashes taken from:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,10 +78,17 @@ end
         chmod(file, 0o644)
         @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
               SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
-        @test artifact_from_directory(tempdir) ==
-              SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
+        if Sys.iswindows()
+            @test artifact_from_directory(tempdir) ==
+                SHA1("952cfce0fb589c02736482fa75f9f9bb492242f8")
+        else
+            @test artifact_from_directory(tempdir) ==
+                SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
+        end
     end
 end
+# Hashes taken from:
+# https://github.com/JuliaLang/Pkg.jl/blob/89286eac216164c43cc996f1f31a9fa1f1dacf87/test/new.jl#L2553-L2572
 
 @testset "git_empty_history" begin
     mktempdir() do git_dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using ArtifactUtils, Pkg.Artifacts
+using Base: SHA1
 using Test
 using TOML
 import Pkg
@@ -32,5 +33,69 @@ end
         @test ispath(_artifact("JuliaMono", tempdir))
         hash = ArtifactUtils.sha256sum(joinpath(_artifact("JuliaMono", tempdir), "JuliaMono-Regular.ttf"))
         @test hash == "dc0af40e8bc944a5d38c049b9a5b33e80b1e7a9621ac30fb440e5a2b6a4192d7"
+    end
+end
+
+@testset "add_artifact!(_, _, ::GistUploadResult)" begin
+    # Dummy `gist` result object
+    gist = ArtifactUtils.GistUploadResult(
+        SHA1("65279f9c8a3dd1e2cb654fdedbe8cd58889ae1bc"),
+        "JuliaMono.tar.gz",
+        "<localpath>",
+        "https://github.com/cormullion/juliamono/releases/download/v0.007/JuliaMono.tar.gz",
+        "f1ab65231cda7981531398644a58fd5fde8f367b681e1b8e9c35d9b2aacfcb1c",
+        false,
+    )
+    mktempdir() do tempdir
+        artifact_file = joinpath(tempdir, "Artifacts.toml")
+        add_artifact!(artifact_file, "JuliaMono", gist)
+        artifacts = TOML.parsefile(artifact_file)
+        @test artifacts == Dict{String,Any}(
+            "JuliaMono" => Dict{String,Any}(
+                "git-tree-sha1" => "65279f9c8a3dd1e2cb654fdedbe8cd58889ae1bc",
+                "download" => Any[
+                    Dict{String,Any}(
+                        "sha256" => "f1ab65231cda7981531398644a58fd5fde8f367b681e1b8e9c35d9b2aacfcb1c",
+                        "url" => "https://github.com/cormullion/juliamono/releases/download/v0.007/JuliaMono.tar.gz",
+                    ),
+                ],
+            ),
+        )
+    end
+    str = sprint(show, "text/plain", gist)
+    @test occursin("upload_to_gist(", str)
+    @test occursin("; private = false)", str)
+    @test occursin("url =", str)
+end
+
+@testset "artifact_from_directory" begin
+    mktempdir() do tempdir
+        write(joinpath(tempdir, "file"), "hello")
+        @test artifact_from_directory(tempdir) ==
+              SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
+    end
+end
+
+@testset "git_empty_history" begin
+    if success(`git --help`)
+        mktempdir() do git_dir
+            git(args) = run(`git --no-pager -C $git_dir $args`)
+            git(`init`)
+            git(`checkout -b new-branch`)
+            write(joinpath(git_dir, "file-1"), "content")
+            git(`add file-1`)
+            git(`commit --message "Add file-1"`)
+            history = strip(read(`git -C $git_dir --no-pager log`, String))
+            @test occursin("Add file-1", history)
+
+            ArtifactUtils.git_empty_history(git_dir)
+            @test !isfile("file-1")
+            branch = strip(
+                read(`git -C $git_dir --no-pager rev-parse --abbrev-ref HEAD`, String),
+            )
+            @test branch == "new-branch"
+            history = strip(read(`git -C $git_dir --no-pager log`, String))
+            @test !occursin("Add file-1", history)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,13 +71,15 @@ end
 
 @testset "artifact_from_directory" begin
     mktempdir() do tempdir
-        file = joinpath(tempdir, "file")
-        write(file, "hello")
+        file = joinpath(tempdir, "hello.txt")
+        open(file, write = true) do io
+            println(io, "Hello, world.")
+        end
         chmod(file, 0o644)
         @test SHA1(Pkg.GitTools.tree_hash(tempdir)) ==
-              SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
+              SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
         @test artifact_from_directory(tempdir) ==
-              SHA1("538e83d637ab07ada6d841aa2454e0d5af4e52b3")
+              SHA1("0a890bd10328d68f6d85efd2535e3a4c588ee8e6")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,11 @@ end
         mktempdir() do git_dir
             git(args) = run(`git --no-pager -C $git_dir $args`)
             git(`init`)
+
+            # Setup repository-local user name and email so that it works on CI
+            git(`config user.email "test@example.com"`)
+            git(`config user.name "tester"`)
+
             git(`checkout -b new-branch`)
             write(joinpath(git_dir, "file-1"), "content")
             git(`add file-1`)


### PR DESCRIPTION
This PR adds new APIs `upload_to_gist` and `artifact_from_directory` to easily share a directory as an artifact via gist.

The example session is in the README: https://github.com/tkf/ArtifactUtils.jl/tree/gist#archive-a-directory-and-upload-it-to-gist