### PR TITLE
Hide internals in documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        hide("Internals" => "internals.md"),
     ],
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,11 +5,10 @@ CurrentModule = ArtifactUtils
 # ArtifactUtils
 
 ```@index
-add_artifact!
-artifact_from_directory
-upload_to_gist
+Pages = ["index.md"]
 ```
 
 ```@autodocs
 Modules = [ArtifactUtils]
+Private = false
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,6 @@
+# Internals
+
+```@autodocs
+Modules = [ArtifactUtils]
+Public = false
+```


### PR DESCRIPTION
I noticed the documentation includes all internals with docstring https://simeonschaub.github.io/ArtifactUtils.jl/stable/. This PR moves all internals to a separate hidden page.

By the way, it looks like `dev` doc https://simeonschaub.github.io/ArtifactUtils.jl/dev/ is older than `stable` doc https://simeonschaub.github.io/ArtifactUtils.jl/stable/. Maybe something wrong with the CI setup?