### PR TITLE
Fix upload_to_gist

### DIFF
--- a/src/gistutils.jl
+++ b/src/gistutils.jl
@@ -32,8 +32,8 @@ function with_new_gist(f; private::Bool = true)
     if m === nothing
         error("Unrecognized output from `gh cli`: ", repo_http)
     end
-    slug = m[1]
-    git_url = "git@gist.github.com:$slug"
+    slug = split(m[1], '/')[2] # remove username
+    git_url = "git@gist.github.com:$slug.git"
 
     response = Ref{HTTP.Response}()
     @sync begin


### PR DESCRIPTION
I was getting the following error:

```
julia> gist = ArtifactUtils.upload_to_gist(artifact_id)
- Creating gist...
✓ Created gist
Cloning into '.'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

with the stack trace:

```
Stacktrace:
  [1] pipeline_error
    @ ./process.jl:565 [inlined]
  [2] run(::Cmd; wait::Bool)
    @ Base ./process.jl:480
  [3] run
    @ ./process.jl:477 [inlined]
  [4] git
    @ ~/.julia/packages/ArtifactUtils/LygoX/src/gistutils.jl:44 [inlined]
  [5] (::ArtifactUtils.var"#15#17"{ArtifactUtils.var"#11#12"{String}, String})(git_dir::String)
    @ ArtifactUtils ~/.julia/packages/ArtifactUtils/LygoX/src/gistutils.jl:45
  [6] mktempdir(fn::ArtifactUtils.var"#15#17"{ArtifactUtils.var"#11#12"{String}, String}, parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:764
  [7] mktempdir (repeats 2 times)
    @ ./file.jl:760 [inlined]
  [8] macro expansion
    @ ~/.julia/packages/ArtifactUtils/LygoX/src/gistutils.jl:43 [inlined]
  [9] macro expansion
    @ ./task.jl:454 [inlined]
 [10] with_new_gist(f::ArtifactUtils.var"#11#12"{String}; private::Bool)
    @ ArtifactUtils ~/.julia/packages/ArtifactUtils/LygoX/src/gistutils.jl:39
 [11] gist_from_file(filepath::String; private::Bool)
    @ ArtifactUtils ~/.julia/packages/ArtifactUtils/LygoX/src/gistutils.jl:10
 [12] upload_to_gist(artifact_id::Base.SHA1, tarball::String; private::Bool, archive_options::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ ArtifactUtils ~/.julia/packages/ArtifactUtils/LygoX/src/ArtifactUtils.jl:172
 [13] upload_to_gist
    @ ~/.julia/packages/ArtifactUtils/LygoX/src/ArtifactUtils.jl:163 [inlined]
 [14] #32
    @ ~/.julia/packages/ArtifactUtils/LygoX/src/ArtifactUtils.jl:205 [inlined]
 [15] mktempdir(fn::ArtifactUtils.var"#32#33"{Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, Base.SHA1, String}, parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:764
 [16] mktempdir (repeats 2 times)
    @ ./file.jl:760 [inlined]
 [17] #upload_to_gist#31
    @ ~/.julia/packages/ArtifactUtils/LygoX/src/ArtifactUtils.jl:204 [inlined]
 [18] upload_to_gist(artifact_id::Base.SHA1)
    @ ArtifactUtils ~/.julia/packages/ArtifactUtils/LygoX/src/ArtifactUtils.jl:183
 [19] top-level scope
    @ REPL[3]:1
```

When checking the repo URL that ArtifactUtils was using, I realised that it also did not work on the terminal. One needs to remove the username and `.git` in the end to actually get the gist repo url. This PR attempts to fix that. I'm actually not sure how ArtifactUtils was working before?

Related: https://discourse.julialang.org/t/permissions-error-in-artifactutils-upload-to-gist/96469